### PR TITLE
包含中文时不能正常使用，

### DIFF
--- a/Main/Auto.bat
+++ b/Main/Auto.bat
@@ -1,22 +1,21 @@
 @echo off
-
 cd allServer
-rem 选择选项
-echo ----------------------1. Japan的A服务器----------------------
+rem select the server
+echo ----------------------1. Japan-A-Server----------------------
 echo.
-echo ----------------------2. Japan的B服务器----------------------
+echo ----------------------2. Japan-B-Server----------------------
 echo.
-echo ----------------------3. Japan的C服务器----------------------
+echo ----------------------3. Japan-C-Server----------------------
 echo.
-echo ----------------------4. Singapore的A服务器----------------------
+echo ----------------------4. Singapore-A-Server----------------------
 echo.
-echo ----------------------5. Singapore的B服务器----------------------
+echo ----------------------5. Singapore-B-Server----------------------
 echo.
-echo ----------------------6. Singapore的C服务器----------------------
+echo ----------------------6. Singapore-C-Server----------------------
 echo.
-echo ----------------------7. Usa的A服务器----------------------
+echo ----------------------7. Usa-A-Server----------------------
 echo.
-CHOICE /C 1234567 /M 请选择你要使用的服务器
+CHOICE /C 1234567 /M Please--Input--the--Server--Num
 
 if %errorlevel%==1 goto JapanA
 if %errorlevel%==2 goto JapanB


### PR DESCRIPTION
按现在的修改后，bat脚本才能正常使用，不知道为什么？
还有一点，如果在脚本里加上语句：call Shadowsocks.exe 会不会更方便？？